### PR TITLE
asyncio/pexpect fixes, small improvements

### DIFF
--- a/pantograph/utils.py
+++ b/pantograph/utils.py
@@ -13,7 +13,7 @@ import regex as re
 def to_sync(func):
     @F.wraps(func)
     def wrapper(*args, **kwargs):
-        return asyncio.get_event_loop().run_until_complete(func(*args, **kwargs))
+        return asyncio.run(func(*args, **kwargs))
     return wrapper
 
 async def check_output(*args, **kwargs):


### PR DESCRIPTION
- Fix the `to_sync` wrapper for when no event loop is running (e.g. in an interactive session).
- Circumvent `pexpect` bug in `readline_async`.
- Small improvements in comments and error handling.