### PR TITLE
fix: Repl copy source path on Windows

### DIFF
--- a/build.py
+++ b/build.py
@@ -11,7 +11,10 @@ with subprocess.Popen(["lake", "build", "repl"], cwd=PATH_PANTOGRAPH) as p:
     p.wait()
 
 path_executable = PATH_PY / "pantograph-repl"
-shutil.copyfile(PATH_PANTOGRAPH / ".lake/build/bin/repl", path_executable)
+if os.name == 'nt': # check that the OS is Windows or not
+    shutil.copyfile(PATH_PANTOGRAPH / ".lake/build/bin/repl.exe", path_executable) 
+else:
+    shutil.copyfile(PATH_PANTOGRAPH / ".lake/build/bin/repl", path_executable)
 os.chmod(path_executable, os.stat(path_executable).st_mode | stat.S_IEXEC)
 
 # -- Copy the Lean toolchain file to the specified path

--- a/build.py
+++ b/build.py
@@ -11,11 +11,8 @@ with subprocess.Popen(["lake", "build", "repl"], cwd=PATH_PANTOGRAPH) as p:
     p.wait()
 
 path_executable = PATH_PY / "pantograph-repl"
-if os.name == 'nt': # check that the OS is Windows or not
-    shutil.copyfile(PATH_PANTOGRAPH / ".lake/build/bin/repl.exe", path_executable) 
-else:
-    shutil.copyfile(PATH_PANTOGRAPH / ".lake/build/bin/repl", path_executable)
+repl_src = "repl.exe" if os.name == "nt" else "repl"
+shutil.copyfile(PATH_PANTOGRAPH / f".lake/build/bin/{repl_src}", path_executable)
 os.chmod(path_executable, os.stat(path_executable).st_mode | stat.S_IEXEC)
-
 # -- Copy the Lean toolchain file to the specified path
 shutil.copyfile(PATH_PANTOGRAPH / "lean-toolchain", PATH_PY / "lean-toolchain")


### PR DESCRIPTION
This fixes issue #67, using `repl.exe` if the user is on Windows (`os.name == 'nt'`), or `repl` otherwise.