### PR TITLE
Fix build process when building in isolated environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,29 @@ A Machine-to-Machine Interaction System for Lean 4.
 ## Installation
 
 1. Install `uv`
-2. Clone this repository with submodules:
+```sh
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+2. Install `elan` and `lake`: See [Lean Manual](https://docs.lean-lang.org/lean4/doc/setup.html)
+
+### Install as a project dependency
+3. Add the package to your project (`--tag` is optional):
+```sh
+uv add git+https://github.com/stanford-centaur/PyPantograph --tag v0.3.0
+uv sync
+```
+
+### Build wheels from source
+3. Clone this repository with submodules:
 ```sh
 git clone --recurse-submodules <repo-path>
 ```
-3. Install `elan` and `lake`: See [Lean Manual](https://docs.lean-lang.org/lean4/doc/setup.html)
 4. Execute
 ```sh
 cd <repo-path>
-uv sync
+uv build
 ```
+5. Built wheels can be found at `dist/*.whl`
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -5,19 +5,18 @@ A Machine-to-Machine Interaction System for Lean 4.
 ## Installation
 
 1. Install `uv`
-```sh
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-2. Install `elan` and `lake`: See [Lean Manual](https://docs.lean-lang.org/lean4/doc/setup.html)
+2. Install `elan`: See [Lean Manual](https://docs.lean-lang.org/lean4/doc/setup.html)
 
 ### Install as a project dependency
-3. Add the package to your project (`--tag` is optional):
+
+3. Add the package to your project:
 ```sh
-uv add git+https://github.com/stanford-centaur/PyPantograph --tag v0.3.0
+uv add git+https://github.com/stanford-centaur/PyPantograph
 uv sync
 ```
 
 ### Build wheels from source
+
 3. Clone this repository with submodules:
 ```sh
 git clone --recurse-submodules <repo-path>

--- a/build-pantograph.py
+++ b/build-pantograph.py
@@ -3,16 +3,26 @@
 import subprocess, shutil, os, stat
 from pathlib import Path
 
-# -- Install Panograph
-# Define paths for Pantograph source and Pantograph Python interface
+# -- Define paths for Pantograph source and Pantograph Python interface
 PATH_PANTOGRAPH = Path("./src")
 PATH_PY = Path("./pantograph")
+
+# -- Build the REPL
 with subprocess.Popen(["lake", "build", "repl"], cwd=PATH_PANTOGRAPH) as p:
     p.wait()
+    if p.returncode != 0:
+        raise Exception(f"Error: 'lake build repl' failed with exit code {p.returncode}.")
 
+# -- Copy the REPL executable to the specified path
 path_executable = PATH_PY / "pantograph-repl"
 repl_src = "repl.exe" if os.name == "nt" else "repl"
 shutil.copyfile(PATH_PANTOGRAPH / f".lake/build/bin/{repl_src}", path_executable)
+
+# -- Make the REPL executable executable
 os.chmod(path_executable, os.stat(path_executable).st_mode | stat.S_IEXEC)
+
 # -- Copy the Lean toolchain file to the specified path
 shutil.copyfile(PATH_PANTOGRAPH / "lean-toolchain", PATH_PY / "lean-toolchain")
+
+# -- Remove src directory (it's not needed anymore)
+shutil.rmtree(PATH_PANTOGRAPH)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "poetry.core.masonry.api"
 include = [
     { path = "pantograph/pantograph-repl", format = ["sdist", "wheel"] },
     { path = "pantograph/lean-toolchain", format = ["sdist", "wheel"] },
+    { path = "src", format = ["sdist", "wheel"] },
 ]
 
 [tool.poetry.build]


### PR DESCRIPTION
This resolves https://github.com/stanford-centaur/PyPantograph/issues/110.
While we include `src/` in the build process, the build script removes `src/` after completion so `src/` is not included in wheel files.