### PR TITLE
chore: Bump to v0.3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pantograph"
-version = "0.3.7"
+version = "0.3.8"
 description = "A machine-to-machine interaction system for Lean"
 license = "Apache-2.0"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -1108,7 +1108,7 @@ wheels = [
 
 [[package]]
 name = "pantograph"
-version = "0.3.7"
+version = "0.3.8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Bumps the version file to 0.3.8 to match the Pantograph version.
- `uv run test` has all tests pass.