### PR TITLE
Avoid asyncio import deprecation warning

### DIFF
--- a/pantograph/test_utils.py
+++ b/pantograph/test_utils.py
@@ -1,0 +1,49 @@
+import subprocess
+import sys
+import textwrap
+
+
+def test_utils_import_is_clean_with_deprecation_warnings_as_errors():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-W",
+            "error::DeprecationWarning",
+            "-c",
+            "import pantograph.utils",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_utils_get_event_loop_preserves_current_event_loop():
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            textwrap.dedent(
+                """
+                import asyncio
+
+                custom_loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(custom_loop)
+
+                import pantograph.utils as utils
+
+                try:
+                    assert utils.get_event_loop() is custom_loop
+                finally:
+                    custom_loop.close()
+                """
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr

--- a/pantograph/utils.py
+++ b/pantograph/utils.py
@@ -1,13 +1,20 @@
 import asyncio
 from pathlib import Path
 import functools as F
+import warnings
 
 DEFAULT_EVENT_LOOP = asyncio.new_event_loop()
 
 def get_event_loop():
     try:
-        return asyncio.get_event_loop()
-    except RuntimeError:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "error",
+                message="There is no current event loop",
+                category=DeprecationWarning,
+            )
+            return asyncio.get_event_loop()
+    except (DeprecationWarning, RuntimeError):
         asyncio.set_event_loop(DEFAULT_EVENT_LOOP)
         return DEFAULT_EVENT_LOOP
 


### PR DESCRIPTION
## Summary
- avoid the Python 3.13 `asyncio.get_event_loop()` import-time deprecation warning when no current event loop exists
- preserve the existing behavior for callers that set a current non-running event loop before importing Pantograph
- add regression coverage for both the warning-as-error import path and the custom event-loop path

## Why
Python 3.13 emits `DeprecationWarning: There is no current event loop` for `asyncio.get_event_loop()` during import when no current loop is set. This currently shows up during pytest collection and becomes an import failure when deprecation warnings are promoted to errors.

The fix keeps the existing fallback to Pantograph's module-level default loop when no current loop exists, while avoiding a behavior regression for users that intentionally call `asyncio.set_event_loop(...)` before import.

## Validation
- `.venv/bin/pytest -q pantograph/test_utils.py` (`2 passed`)
- `.venv/bin/python -W error::DeprecationWarning -c 'import pantograph.utils'`
- `.venv/bin/pytest -q` (`31 passed`)
