### PR TITLE
Run unit tests on pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,12 +1,13 @@
 name: Unit Tests
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
## Summary
- run the existing Unit Tests workflow for `pull_request` events as well as `push` events
- reduce the test job token scope to `contents: read`; Pages/OIDC write permissions are only needed by the documentation deployment workflow

## Why
Contributor PRs currently show no test check rollup unless maintainers run validation separately. Enabling the existing workflow on pull requests makes small maintenance PRs easier to evaluate with the same pytest path already used on pushes.

The test job does not publish GitHub Pages or request an OIDC token, so it can use least-privilege read access.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/test.yaml"); puts "workflow yaml parsed"'`
- `git diff --check`
- `.venv/bin/pytest -q` (`29 passed`, with the pre-existing Python 3.13 asyncio deprecation warning addressed separately in PR #172)
