### PR TITLE
Fix MCTS search state advancement

### DIFF
--- a/pantograph/search.py
+++ b/pantograph/search.py
@@ -298,15 +298,14 @@ class MCTSAgent(Agent):
                 state = search_state.goal_state
                 if verbose:
                     print(f"{state.state_id}.{goal_id}: {tactic} on {search_state.goal_state.goals[goal_id]}")
-                next_goal_state = server.goal_tactic(goal_state, tactic, site=Site(goal_id, auto_resume=False))
+                next_goal_state = server.goal_tactic(state, tactic, site=Site(goal_id, auto_resume=False))
                 # Generate priorities for the next goal state
                 priorities = [0.0 for _ in next_goal_state.goals] \
                     if len(next_goal_state.goals) <= 1 else \
                     self.guidance(next_goal_state)
-                parent = -1
                 next_state = SearchState(
                     goal_state=next_goal_state,
-                    parent=parent,
+                    parent=search_state,
                     parent_goal_id=goal_id,
                     priorities=priorities
                 )

--- a/pantograph/test_search.py
+++ b/pantograph/test_search.py
@@ -13,7 +13,7 @@ class TestSearch(unittest.TestCase):
             goal_state=goal_state,
             verbose=False)
         #flag = agent.search(server=server, target="∀ (p q: Prop), Or p q -> Or q p", verbose=True)
-        self.assertTrue(flag)
+        self.assertTrue(flag.success)
     def test_solve_big(self):
 
         server = Server()
@@ -23,7 +23,7 @@ class TestSearch(unittest.TestCase):
             server=server,
             goal_state=goal_state,
             verbose=False)
-        self.assertTrue(flag)
+        self.assertTrue(flag.success)
 
 class TestMCTSSearch(unittest.TestCase):
 
@@ -37,7 +37,7 @@ class TestMCTSSearch(unittest.TestCase):
             goal_state=goal_state,
             verbose=False)
         #flag = agent.search(server=server, target="∀ (p q: Prop), Or p q -> Or q p", verbose=True)
-        self.assertTrue(flag)
+        self.assertTrue(flag.success)
     def test_solve_big(self):
 
         server = Server()
@@ -48,7 +48,7 @@ class TestMCTSSearch(unittest.TestCase):
             goal_state=goal_state,
             max_steps=200,
             verbose=False)
-        self.assertTrue(flag)
+        self.assertTrue(flag.success)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- advance MCTS search from the selected search node instead of the root goal state
- store the actual parent `SearchState` for MCTS child nodes
- assert `SearchResult.success` in search tests so failed searches no longer pass by object truthiness

## Root cause
`MCTSAgent.search` selected a `SearchState`, but tactic execution still used the original `goal_state` argument. After the first step, MCTS kept applying tactics to the root state rather than the selected node. The existing tests did not catch this because `assertTrue(SearchResult(...))` is truthy even when `success=False`.

## Validation
- `.venv/bin/pytest -q pantograph/test_search.py` (`4 passed`)
- `.venv/bin/pytest -q` (`29 passed`, with the existing Python 3.13 asyncio deprecation warning)
- `git diff --check`
